### PR TITLE
Recording: auto thumbnailer + event notification

### DIFF
--- a/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
+++ b/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
@@ -1,7 +1,7 @@
 [general]
 ; Port range for automatic port generation
-minport = 8000
-maxport = 9000
+; minport = 8000
+; maxport = 9000
 
 ; Path for recording and thumbnailing
 ; archive_path = "/tmp/recordings"
@@ -10,8 +10,14 @@ maxport = 9000
 ; Short usage, the following gets substituted:
 ; %1$s    is streamChannelKey (string)
 ; %2$llu  is timestamp (guint64)
-; %3$s    is type ("audio" or "video" string)
+; %3$s    is type ("audio", "video" or "thumb" string)
 ; recording_pattern = "rec-%1$s-%2$llu-%3$s"
 
-; same for thumbnails
+; Same for thumbnails
 ; thumbnailing_pattern = "thum-%1$s-%2$llu-%3$s"
+
+; Thumbnailing interval in seconds
+; thumbnailing_interval = 60
+
+; Thumbnailing duration in seconds
+; thumbnailing_duration = 10

--- a/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
+++ b/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
@@ -7,10 +7,11 @@ maxport = 9000
 ; archive_path = "/tmp/recordings"
 
 ; printf pattern for recordings filenames
-; #1 is streamChannelKey (string)
-; #2 is timestamp (guint64)
-; #3 is type ("audio" or "video" string)
-; recording_pattern = "rec-%s-%llu-%s"
+; Short usage, the following gets substituted:
+; %1$s    is streamChannelKey (string)
+; %2$llu  is timestamp (guint64)
+; %3$s    is type ("audio" or "video" string)
+; recording_pattern = "rec-%1$s-%2$llu-%3$s"
 
 ; same for thumbnails
-; thumbnailing_pattern = "thum-%s-%llu-%s"
+; thumbnailing_pattern = "thum-%1$s-%2$llu-%3$s"

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -479,8 +479,8 @@ int cm_rtpbcast_init(janus_callbacks *callback, const char *config_path) {
 	cm_rtpbcast_settings.minport = 8000;
 	cm_rtpbcast_settings.maxport = 12000;
 	cm_rtpbcast_settings.archive_path =  g_strdup("/tmp/recordings");
-	cm_rtpbcast_settings.recording_pattern = g_strdup("rec-%s-%llu-%s");
-	cm_rtpbcast_settings.thumbnailing_pattern = g_strdup("thum-%s-%llu-%s");
+	cm_rtpbcast_settings.recording_pattern = g_strdup("rec-%1$s-%2$llu-%3$s");
+	cm_rtpbcast_settings.thumbnailing_pattern = g_strdup("thum-%1$s-%2$llu-%3$s");
 
 	mountpoints = g_hash_table_new_full(
 		g_str_hash,	 /* Hashing func */


### PR DESCRIPTION
TODO:
- investigate best option:
 - RTP server and FFMPEG client with JPEG output
 - dump RTP packets to the file and notify `cm-janus` to convert into JPEG using Gstreamer?
- try to detect KEYFRAME
- send EVENT up to cm-janus

```
{
  "name": "thumbnail-ready",
  "filename": "path-to-the-file"
}
```

