### PR TITLE
Bugs overview

### DIFF
--- a/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
+++ b/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
@@ -6,7 +6,7 @@
 ; NOTE: all paths should exist beforehead
 
 ; Path for job JSONs
-; job_path = "/tmp/jobs"
+; job_path = /tmp/jobs
 
 ; prinf pattern for job filenames (.json is auto)
 ; Short usage, the following gets substituted:
@@ -14,20 +14,20 @@
 ; #{rand}     is random integer (guin32)
 ; #{md5}      is md5 of (timestamp + plugin name + random integer)
 ; #{plugin}   is plugin name ("janus.plugin.cm.rtpbroadcast")
-; job_pattern = "job-#{md5}"
+; job_pattern = job-#{md5}
 
 ; Path for recording and thumbnailing
-; archive_path = "/tmp/recordings"
+; archive_path = /tmp/recordings"
 
 ; printf pattern for recordings filenames
 ; Short usage, the following gets substituted:
 ; #{id}       is streamChannelKey (string)
 ; #{time}     is timestamp (guint64)
 ; #{type}     is type ("audio", "video" or "thumb" string)
-; recording_pattern = "rec-#{id}-#{time}-#{type}"
+; recording_pattern = rec-#{id}-#{time}-#{type}
 
 ; Same for thumbnails
-; thumbnailing_pattern = "thum-#{id}-#{time}-#{type}"
+; thumbnailing_pattern = thum-#{id}-#{time}-#{type}
 
 ; Thumbnailing interval in seconds
 ; thumbnailing_interval = 60


### PR DESCRIPTION
There are some issues

Used config
```
[general]
; Port range for automatic port generation
; minport = 8000
; maxport = 9000

; NOTE: all paths should exist beforehead

; Path for job JSONs
job_path=/var/lib/janus/jobs

; prinf pattern for job filenames (.json is auto)
; Short usage, the following gets substituted:
; #{time}     is timestamp (guint64)
; #{rand}     is random integer (guin32)
; #{md5}      is md5 of (timestamp + plugin name + random integer)
; #{plugin}   is plugin name ("janus.plugin.cm.rtpbroadcast")
job_pattern = "job-#{md5}"

; Path for recording and thumbnailing
archive_path=/var/lib/janus/recordings

; printf pattern for recordings filenames
; Short usage, the following gets substituted:
; #{id}       is streamChannelKey (string)
; #{time}     is timestamp (guint64)
; #{type}     is type ("audio", "video" or "thumb" string)
recording_pattern = "rec-#{id}-#{time}-#{type}"

; Same for thumbnails
thumbnailing_pattern = "thum-#{id}-#{time}-#{type}"

; Thumbnailing interval in seconds
thumbnailing_interval = 10

; Thumbnailing duration in seconds
thumbnailing_duration = 10
```

##### Recording
`Mountpoint` was successfully `created` and `destroyed`
- doesn't create `record` file
- doesn't create `job` file

##### Thumbnailer
- creates file with wrong name
```
$ ls -laph /var/lib/janus/recordings/
total 2.0M
drwxr-xr-x 2 root root 4.0K Nov 13 16:51 ./
drwxr-xr-x 4 root root 4.0K Nov 13 14:49 ../
-rw-r--r-- 1 root root 325K Nov 13 16:58 "thum-#{id}-#{time}-#{type}".mjr
```

- doesn't create `job` file

##### Converting to `webm`
Could not create to any useful format as there are no output files!