### PR TITLE
Stream switching: Cannot destroy mountpoint, close session, shutdown Janus

### DIFF
--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -1423,10 +1423,10 @@ void cm_rtpbcast_incoming_rtcp(janus_plugin_session *handle, int video, char *bu
 
 		/* If it's first measurement, start the timer */
 		guint64 ml = janus_get_monotonic_time();
-		if (!sessid->last_remb_usec)
+		if (!sessid->last_remb_usec) {
 			sessid->last_remb_usec = ml;
 		/* Otherwise check if we stepped out */
-		else if (ml - sessid->last_remb_usec >= cm_rtpbcast_settings.remb_avg_time * STAT_SECOND) {
+		} else if (ml - sessid->last_remb_usec >= cm_rtpbcast_settings.remb_avg_time * STAT_SECOND) {
 			/* Calculate average */
 			sessid->remb = sessid->rembcount? sessid->rembsum / sessid->rembcount : 0;
 
@@ -1443,7 +1443,7 @@ void cm_rtpbcast_incoming_rtcp(janus_plugin_session *handle, int video, char *bu
 				cm_rtpbcast_pick_source(sessid->source->mp->sources, sessid->remb);
 
 			/* Check if we really need to switch */
-			if (src != sessid->source) {
+			if (src && src != sessid->source) {
 				janus_mutex_lock(&sessid->source->mutex);
 				sessid->source->listeners = g_list_remove_all(sessid->source->listeners, sessid);
 				sessid->source = src;

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -1452,8 +1452,10 @@ void cm_rtpbcast_incoming_rtcp(janus_plugin_session *handle, int video, char *bu
 			if (sessid->source->mp->sources == NULL)
 				return;
 
+			janus_mutex_lock(&sessid->source->mutex);
 			cm_rtpbcast_rtp_source *src =
 				cm_rtpbcast_pick_source(sessid->source->mp->sources, sessid->remb);
+			janus_mutex_unlock(&sessid->source->mutex);
 
 			/* Check if we really need to switch */
 			if (src && src != sessid->source) {

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -1443,6 +1443,9 @@ void cm_rtpbcast_incoming_rtcp(janus_plugin_session *handle, int video, char *bu
 				oldremb != sessid->remb && sessid->remb != 0 &&
 					ml - sessid->last_switch >= cm_rtpbcast_settings.switching_delay * STAT_SECOND ) {
 
+			if (sessid->source == NULL)
+				return;
+
 			if (sessid->source->mp == NULL)
 				return;
 

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -1443,9 +1443,6 @@ void cm_rtpbcast_incoming_rtcp(janus_plugin_session *handle, int video, char *bu
 				oldremb != sessid->remb && sessid->remb != 0 &&
 					ml - sessid->last_switch >= cm_rtpbcast_settings.switching_delay * STAT_SECOND ) {
 
-			if (sessid->source == NULL)
-				return;
-
 			if (sessid->source->mp == NULL)
 				return;
 

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -1411,6 +1411,9 @@ void cm_rtpbcast_incoming_rtcp(janus_plugin_session *handle, int video, char *bu
 	if (sessid == NULL)
 		return;
 
+	if (sessid->stopping || sessid->paused)
+		return;
+
 	/* We might interested in the available bandwidth that the user advertizes */
 	uint64_t bw = janus_rtcp_get_remb(buf, len);
 	if(bw > 0) {
@@ -1439,6 +1442,16 @@ void cm_rtpbcast_incoming_rtcp(janus_plugin_session *handle, int video, char *bu
 		if (sessid->source &&
 				oldremb != sessid->remb && sessid->remb != 0 &&
 					ml - sessid->last_switch >= cm_rtpbcast_settings.switching_delay * STAT_SECOND ) {
+
+			if (sessid->source == NULL)
+				return;
+
+			if (sessid->source->mp == NULL)
+				return;
+
+			if (sessid->source->mp->sources == NULL)
+				return;
+
 			cm_rtpbcast_rtp_source *src =
 				cm_rtpbcast_pick_source(sessid->source->mp->sources, sessid->remb);
 

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2306,12 +2306,13 @@ cm_rtpbcast_rtp_source* cm_rtpbcast_pick_source(GArray *sources, guint64 remb) {
 	/* Pick the source with bitrate less than REMB given or the worst quality if
 	   no such source found */
 	guint i = 0; cm_rtpbcast_rtp_source *src; guint64 source_remb;
+	guint s_count = sources->len;
 	do {
 		src = g_array_index(sources, cm_rtpbcast_rtp_source *, i++);
 		janus_mutex_lock(&src->stats.stat_mutex);
 		source_remb = (guint64)src->stats.avg;
 		janus_mutex_unlock(&src->stats.stat_mutex);
-	} while (i < sources->len && remb < source_remb);
+	} while (i < s_count && remb < source_remb);
 
 	return src;
 }


### PR DESCRIPTION
##### PROPER WORKFLOW - from session create to Janus shutdown
```
Creating new session: 3359450195
Creating new handle in session 3359450195: 3723401204
[<string>] Recording audio started
[<string>] Recording video started
[<string>] New audio stream! (ssrc=906131872)
[<string>] New video stream! (ssrc=1563571768)
[<string>] New audio stream! (ssrc=3063090431)
[<string>] New video stream! (ssrc=1891070994)
[2650383836] Creating ICE agent (ICE Full mode, controlling)

(process:15154): libnice-WARNING **: Could not find component 1 in stream 2

(process:15154): libnice-WARNING **: Could not find component 2 in stream 2
[2650383836] The DTLS handshake has been completed
WebRTC media is now available
[WSS-0x1ac0100] Destroying WebSocket client
Timeout expired for session 3359450195...
Detaching handle from JANUS CM video plugin
No WebRTC media anymore
[2650383836] WebRTC resources freed
File is 179321 bytes: rec-<string>-103457685408-audio.mjr
[<string>] Closed audio recording /tmp/recordings/rec-<string>-103457685408-audio.mjr
File is 5031797 bytes: rec-<string>-103457685552-video.mjr
[<string>] Closed video recording /tmp/recordings/rec-<string>-103457685552-video.mjr
Cleaning up handle 3723401204...
[3723401204] WebRTC resources freed
[3723401204] Handle and related resources freed
^CStopping gateway, please wait...
Ending watchdog mainloop...
Closing transport plugins:
Stopping webserver(s)...
HTTP/Janus sessions watchdog stopped
JANUS REST (HTTP/HTTPS) transport plugin destroyed!
WebSocket (Janus API) thread ended
JANUS WebSockets transport plugin destroyed!
Destroying sessions...
Freeing crypto resources...
Cleaning SDP structures...
De-initializing SCTP...
Ending ICE handles watchdog mainloop...
Closing plugins:
VoiceMail watchdog stopped
JANUS VoiceMail plugin destroyed!
AudioBridge watchdog stopped
JANUS AudioBridge plugin destroyed!
EchoTest watchdog stopped
JANUS EchoTest plugin destroyed!
Record&Play watchdog stopped
JANUS Record&Play plugin destroyed!
CM RTP Broadcast watchdog stopped
JANUS CM video plugin destroyed!
VideoRoom watchdog stopped
JANUS VideoRoom plugin destroyed!
VideoCall watchdog stopped
JANUS VideoCall plugin destroyed!
Streaming watchdog stopped
JANUS Streaming plugin destroyed!
SIP watchdog stopped
JANUS SIP plugin destroyed!
Bye!
```

##### BAD WORKFLOW - from session create to Janus shutdown
```
Creating new session: 3906555800
Creating new handle in session 3906555800: 3747294112
[<string>] Recording audio started
[<string>] Recording video started
[<string>] New audio stream! (ssrc=3395869979)
[<string>] New video stream! (ssrc=1592705360)
[<string>] New audio stream! (ssrc=3559579016)
[<string>] New video stream! (ssrc=1696415100)
[2823104347] Creating ICE agent (ICE Full mode, controlling)

(process:15365): libnice-WARNING **: Could not find component 1 in stream 2

(process:15365): libnice-WARNING **: Could not find component 2 in stream 2
[2823104347] The DTLS handshake has been completed
WebRTC media is now available
[<string>] Recording thumb started
File is 872118 bytes: thum-<string>-104217424729-thumb.mjr
[<string>] Closed thumb recording /tmp/recordings/thum-<string>-104217424729-thumb.mjr
No WebRTC media anymore
[2823104347] WebRTC resources freed
[WSS-0x163d000] Destroying WebSocket client
Timeout expired for session 3906555800...
Detaching handle from JANUS CM video plugin
^CStopping gateway, please wait...
Ending watchdog mainloop...
```

The problem is that somehow process hangs, mountpoint is not closed, recording is not stored and Janus cannot shutdown!