### PR TITLE
Refactor UDP client inner structures

### DIFF
--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2467,12 +2467,12 @@ static void *cm_rtpbcast_relay_thread(void *data) {
 		/* Let's create and verify the hostname */
 		struct hostent *host = gethostbyname(hostname);
 		if (host == NULL) {
-			JANUS_LOG(LOG_ERR, "UDP:Send: cannot get hostname!\n");
+			JANUS_LOG(LOG_ERR, "UDP:Send: cannot get hostname! Reason: %s\n", strerror(errno));
 			return -1;
 		}
 		/* Let's initialize socket for UDP */
 		if ((fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
-			JANUS_LOG(LOG_ERR, "UDP:Send: cannot create socket!\n");
+			JANUS_LOG(LOG_ERR, "UDP:Send: cannot create socket! Reason: %s\n", strerror(errno));
 			return -1;
 		}
 		/* Let's initialize server address */
@@ -2487,7 +2487,7 @@ static void *cm_rtpbcast_relay_thread(void *data) {
 
 		/* Setting the socket destination address, with UDP doesn't really connect */
 		if (connect(fd, (struct sockaddr *)&sin, sizeof(struct sockaddr_in)) == -1) {
-			JANUS_LOG(LOG_ERR, "UDP:Send: cannot connect socket!\n");
+			JANUS_LOG(LOG_ERR, "UDP:Send: cannot connect socket! Reason: %s\n", strerror(errno));
 			return -1;
 		}
 
@@ -2500,7 +2500,7 @@ int cm_rtpbcast_relay_rtp_packet_via_udp(cm_rtpbcast_session *session, int sourc
 			int fd = gateway.sockfd[isvideo];
 			if(fd != -1) {
 				if (send(fd, buf, buf_len, 0) == -1) {
-					JANUS_LOG(LOG_ERR, "UDP:Send: cannot send message!\n");
+					JANUS_LOG(LOG_ERR, "UDP:Send: cannot send message! Reason %s\n", strerror(errno));
 					return 1;
 				}
 				return 0;

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -1774,16 +1774,17 @@ static void *cm_rtpbcast_handler(void *data) {
 
 				cm_rtpbcast_rtp_source *src = g_array_index(mp->sources, cm_rtpbcast_rtp_source *, i);
 
-				janus_mutex_lock(&src->mutex);
-				src->listeners = g_list_append(src->listeners, session);
-				janus_mutex_unlock(&src->mutex);
-
 				/* Let's create UDP gateway for Audio and Video */
 				cm_rtpbcast_udp_relay_gateway udp_gateway;
 				for (j = AUDIO; j <= VIDEO; j++)
 					udp_gateway.sockfd[j] = cm_rtpbcast_udp_client_create(hostname[j], port[j]);
-				g_array_append_val(session->relay_udp_gateways, udp_gateway);
 				udp_gateway->source = src;
+				g_array_append_val(session->relay_udp_gateways, udp_gateway);
+
+				/* All preparations are done, add the session to watchers */
+				janus_mutex_lock(&src->mutex);
+				src->listeners = g_list_append(src->listeners, session);
+				janus_mutex_unlock(&src->mutex);
 			}
 
 			/* Let's configure session with UDP relay type */

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -1778,7 +1778,7 @@ static void *cm_rtpbcast_handler(void *data) {
 				cm_rtpbcast_udp_relay_gateway udp_gateway;
 				for (j = AUDIO; j <= VIDEO; j++)
 					udp_gateway.sockfd[j] = cm_rtpbcast_udp_client_create(hostname[j], port[j]);
-				udp_gateway->source = src;
+				udp_gateway.source = src;
 				g_array_append_val(session->relay_udp_gateways, udp_gateway);
 
 				/* All preparations are done, add the session to watchers */
@@ -3009,15 +3009,15 @@ void cm_rtpbcast_stop_udp_relays(cm_rtpbcast_session *session, cm_rtpbcast_rtp_s
 	/* Remove ourselves from every source */
 	int i;
 	for (i = 0; i < session->relay_udp_gateways->len; i++) {
-		cm_rtpbcast_udp_relay_gateway *gw = g_array_index(session->relay_udp_gateways, cm_rtpbcast_udp_relay_gateway *, i);
+		cm_rtpbcast_udp_relay_gateway gw = g_array_index(session->relay_udp_gateways, cm_rtpbcast_udp_relay_gateway, i);
 
 		/* This function can be called from within mountpoint_destroy() which has a mutex locked over one source
 		 * so we check the argument here to prevent deadlocking */
-		if (srcmx != gw->source)
-			janus_mutex_lock(&gw->source->mutex);
-		gw->source->listeners = g_list_remove_all(gw->source->listeners, session);
-		if (srcmx != gw->source)
-			janus_mutex_unlock(&gw->source->mutex);
+		if (srcmx != gw.source)
+			janus_mutex_lock(&gw.source->mutex);
+		gw.source->listeners = g_list_remove_all(gw.source->listeners, session);
+		if (srcmx != gw.source)
+			janus_mutex_unlock(&gw.source->mutex);
 	}
 
 	g_array_free(session->relay_udp_gateways, TRUE);


### PR DESCRIPTION
@kris-lab @njam I'll summarise my findings about the bug here. The bug is caused by the following:
1. Session `A` creates a mountpoint `M`.
2. Session `B` initiates `watch-udp` to this mountpoint, this spawns 3 instances of `cm_rtpbcast_udp_relay_gateway` into a `GArray`. Each of `M`'s sources add `B` to their `listeners` list. 
3. **Here is the error** compared to what I have in `watch`, `B` has no way of knowing which sources to it is connected.
4. `B` disconnects, times out or whatever. Since (3) it does not remove itself from `listeners` anywhere.
5. `A` disconnects, times out or whatever. It goes through `listeners` of each sources for the mountpoint it streams, then it tries to send shutdown signals to the session `A` which has already quit. This is timing dependent because `B` is not removed immediately on (4) and rather added to a special list which is removed by watchdog, this is why the bug was unreliable to reproduce. 

Similarly, if `A` quits faster than `B`, then `B` will have no way of knowing this has happened and consider that it still streams something. Moreover, @kris-lab's implementation used a `GArray` while when we have `B` issue more than one `watch-udp` request we'll have to enlarge the array. This would would backfire when we remove certain of UDP clients on session `A` shotdown so I am making a `GList` here instead.

Hopefully will deliver right now so that we are no longer blocked for tomorrow. 

Please kill #70 it's not needed anymore. I'll cherrypick parts of the source from there. 