### PR TITLE
Return public RTP host on "mountpoint creation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ The response for multiple actions contains the `stream-definition` like follows:
 - `id` is the mountpoint identification
 - `index` is position of stream in the mountpoint/streams array
 - `session` is set only for `list` action and reference to current connection/session
-- `cur_loss` is an estimate of UDP packets loss for the window of last `source_avg_time` seconds as regular stats
-- `avg_loss` is an estimate of UDP packets loss for the whole time the connection is on
+- `packet-loss/cur` is an estimate of UDP packets loss for the window of last `source_avg_time` seconds as regular stats
+- `packet-loss/avg` is an estimate of UDP packets loss for the whole time the connection is on
 
 #### Mountpoint definition for responses
 The response for multiple actions contains the `mountpoint-definition` like follows:

--- a/README.md
+++ b/README.md
@@ -100,22 +100,40 @@ The response for multiple actions contains the `stream-definition` like follows:
    "id": "<string>",
    "uid": "<string>",
    "index": "<int>",
-   "audioport": "<int>",
-   "videoport": "<int>",
+   "audio": {
+      "port": "<int>",
+      "host": "<string|null>"
+   },
+   "video": {
+      "port": "<int>",
+      "host": "<string|null>"
+   },
    "listeners": "<int>",
    "waiters": "<int>",
    "stats": {
-      "min": "<float>",
-      "max": "<float>",
-      "cur": "<float>",
-      "avg": "<float>",
       "audio": {
-         "cur_loss": "<float>",
-         "avg_loss": "<float>"
+          "bitrate": {
+              "max": "<int|null>",
+              "avg": "<int|null>",
+              "cur": "<int|null>",
+              "min": "<int|null>"
+          },
+          "udp-loss": {
+              "avg": "<int|null>",
+              "cur": "<int|null>"
+          }
       },
       "video": {
-         "cur_loss": "<float>",
-         "avg_loss": "<float>"
+          "bitrate": {
+              "max": "<int|null>",
+              "avg": "<int|null>",
+              "cur": "<int|null>",
+              "min": "<int|null>"
+          },
+          "udp-loss": {
+              "avg": "<int|null>",
+              "cur": "<int|null>"
+          }
       }
    },
    "frame": {
@@ -127,7 +145,7 @@ The response for multiple actions contains the `stream-definition` like follows:
    "session": {
       "webrtc-active": "<boolean>",
       "autoswitch-enabled": "<boolean>",
-      "remb-avg": "<int>"
+      "remb-avg": "<int|null>"
    }
 }
 ```
@@ -196,8 +214,14 @@ It responses with auto generated port number for audio and video using `minport`
     "description": "<string>",
     "streams": [
       {
-        "audioport": "<int>",
-        "videoport": "<int>",
+        "audio": {
+          "port": "<int>",
+          "host": "<string>"
+         },
+        "video": {
+          "port": "<int>",
+          "host": "<string>"
+         }
       }
     ]
   }

--- a/README.md
+++ b/README.md
@@ -103,16 +103,20 @@ The response for multiple actions contains the `stream-definition` like follows:
    "id": "<string>",
    "uid": "<string>",
    "index": "<int>",
-   "audio": {
-      "port": "<int>",
-      "host": "<string|null>"
+   "rtp-endpoint": {
+     "audio": {
+        "port": "<int>",
+        "host": "<string>"
+     },
+     "video": {
+        "port": "<int>",
+        "host": "<string>"
+     },
    },
-   "video": {
-      "port": "<int>",
-      "host": "<string|null>"
+   "webrtc-endpoint": {
+    "listeners": "<int>",
+    "waiters": "<int>",
    },
-   "listeners": "<int>",
-   "waiters": "<int>",
    "stats": {
       "audio": {
           "bitrate": {

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The response for multiple actions contains the `stream-definition` like follows:
               "cur": "<int|null>",
               "min": "<int|null>"
           },
-          "udp-loss": {
+          "packet-loss": {
               "avg": "<int|null>",
               "cur": "<int|null>"
           }
@@ -133,7 +133,7 @@ The response for multiple actions contains the `stream-definition` like follows:
               "cur": "<int|null>",
               "min": "<int|null>"
           },
-          "udp-loss": {
+          "packet-loss": {
               "avg": "<int|null>",
               "cur": "<int|null>"
           }

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Configuration
 -------------
 ```
 [general]
+; Hostname to use. Will be used in API responses.
+; hostname = localhost
+
 ; Port range for automatic port generation
 ; minport = 8000
 ; maxport = 9000

--- a/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
+++ b/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
@@ -1,7 +1,6 @@
 [general]
-; Public interface of this instance. Can be set to FQDN or IP.
-; By default is empty and not included in any API response.
-; hostname =
+; Hostname to use. Will be used in API responses.
+; hostname = localhost
 
 ; Port range for automatic port generation
 ; minport = 8000

--- a/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
+++ b/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
@@ -1,4 +1,8 @@
 [general]
+; Public interface of this instance. Can be set to FQDN or IP.
+; By default is empty and not included in any API response.
+; hostname =
+
 ; Port range for automatic port generation
 ; minport = 8000
 ; maxport = 9000
@@ -40,7 +44,7 @@
 ; recording_enabled = yes
 
 ; Path for recording and thumbnailing
-; archive_path = /tmp/recordings"
+; archive_path = /tmp/recordings
 
 ; printf pattern for recordings filenames
 ; Short usage, the following gets substituted:

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -1407,9 +1407,9 @@ struct janus_plugin_result *cm_rtpbcast_handle_message(janus_plugin_session *han
 			json_t *video = json_object();
 
 			json_object_set_new(audio, "port", json_integer(g_array_index(mp->sources, cm_rtpbcast_rtp_source*, i)->port[AUDIO]));
-			json_object_set_new(audio, "host", json_string(g_strdup(cm_rtpbcast_settings.hostname)));
+			json_object_set_new(audio, "host", (cm_rtpbcast_settings.hostname) ? json_string(g_strdup(cm_rtpbcast_settings.hostname)) : json_null());
 			json_object_set_new(video, "port", json_integer(g_array_index(mp->sources, cm_rtpbcast_rtp_source*, i)->port[VIDEO]));
-			json_object_set_new(video, "host", json_string(g_strdup(cm_rtpbcast_settings.hostname)));
+			json_object_set_new(video, "host", (cm_rtpbcast_settings.hostname) ? json_string(g_strdup(cm_rtpbcast_settings.hostname)) : json_null());
 
 			json_object_set_new(v, "audio", audio);
 			json_object_set_new(v, "video", video);
@@ -3482,9 +3482,9 @@ json_t *cm_rtpbcast_source_to_json(cm_rtpbcast_rtp_source *src, cm_rtpbcast_sess
 	json_t *audio = json_object();
 	json_t *video = json_object();
 	json_object_set_new(audio, "port", json_integer(src->port[AUDIO]));
-	json_object_set_new(audio, "host", json_string(g_strdup(cm_rtpbcast_settings.hostname)));
+	json_object_set_new(audio, "host", (cm_rtpbcast_settings.hostname) ? json_string(g_strdup(cm_rtpbcast_settings.hostname)) : json_null());
 	json_object_set_new(video, "port", json_integer(src->port[VIDEO]));
-	json_object_set_new(video, "host", json_string(g_strdup(cm_rtpbcast_settings.hostname)));
+	json_object_set_new(video, "host", (cm_rtpbcast_settings.hostname) ? json_string(g_strdup(cm_rtpbcast_settings.hostname)) : json_null());
 	json_object_set_new(v, "audio", audio);
 	json_object_set_new(v, "video", video);
 
@@ -3503,8 +3503,7 @@ json_t *cm_rtpbcast_source_to_json(cm_rtpbcast_rtp_source *src, cm_rtpbcast_sess
 	json_t *u = json_object();
 	json_object_set_new(u, "webrtc-active", json_integer(session->source == src));
 	json_object_set_new(u, "autoswitch-enabled", json_integer(session->autoswitch));
-	json_object_set_new(u, "remb-avg", json_integer(session->remb));
-	json_object_set_new(u, "remb-avg-test", (session->remb == -1)? json_null() : json_integer(session->remb));
+	json_object_set_new(u, "remb-avg", (session->remb == -1)? json_null() : json_integer(session->remb));
 	json_object_set_new(v, "session", u);
 
 	return v;

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -757,7 +757,7 @@ int cm_rtpbcast_init(janus_callbacks *callback, const char *config_path) {
 		janus_config_print(config);
 
 	/* Defauts */
-	cm_rtpbcast_settings.hostname = NULL;
+	cm_rtpbcast_settings.hostname = g_strdup("localhost");
 	cm_rtpbcast_settings.minport = 8000;
 	cm_rtpbcast_settings.maxport = 9000;
 	cm_rtpbcast_settings.source_avg_time = 10;
@@ -765,7 +765,7 @@ int cm_rtpbcast_init(janus_callbacks *callback, const char *config_path) {
 	cm_rtpbcast_settings.switching_delay = 1;
 	cm_rtpbcast_settings.session_info_update_time = 10;
 	cm_rtpbcast_settings.udp_relay_interval = 50000;
-	cm_rtpbcast_settings.job_path =  g_strdup("/tmp/jobs");
+	cm_rtpbcast_settings.job_path = g_strdup("/tmp/jobs");
 	cm_rtpbcast_settings.job_pattern = g_strdup("job-#{md5}");
 	cm_rtpbcast_settings.archive_path =  g_strdup("/tmp/recordings");
 	cm_rtpbcast_settings.recording_pattern = g_strdup("rec-#{id}-#{time}-#{type}");
@@ -1407,9 +1407,9 @@ struct janus_plugin_result *cm_rtpbcast_handle_message(janus_plugin_session *han
 			json_t *video = json_object();
 
 			json_object_set_new(audio, "port", json_integer(g_array_index(mp->sources, cm_rtpbcast_rtp_source*, i)->port[AUDIO]));
-			json_object_set_new(audio, "host", (cm_rtpbcast_settings.hostname) ? json_string(g_strdup(cm_rtpbcast_settings.hostname)) : json_null());
+			json_object_set_new(audio, "host", json_string(g_strdup(cm_rtpbcast_settings.hostname)));
 			json_object_set_new(video, "port", json_integer(g_array_index(mp->sources, cm_rtpbcast_rtp_source*, i)->port[VIDEO]));
-			json_object_set_new(video, "host", (cm_rtpbcast_settings.hostname) ? json_string(g_strdup(cm_rtpbcast_settings.hostname)) : json_null());
+			json_object_set_new(video, "host", json_string(g_strdup(cm_rtpbcast_settings.hostname)));
 
 			json_object_set_new(v, "audio", audio);
 			json_object_set_new(v, "video", video);
@@ -3482,9 +3482,9 @@ json_t *cm_rtpbcast_source_to_json(cm_rtpbcast_rtp_source *src, cm_rtpbcast_sess
 	json_t *audio = json_object();
 	json_t *video = json_object();
 	json_object_set_new(audio, "port", json_integer(src->port[AUDIO]));
-	json_object_set_new(audio, "host", (cm_rtpbcast_settings.hostname) ? json_string(g_strdup(cm_rtpbcast_settings.hostname)) : json_null());
+	json_object_set_new(audio, "host", json_string(g_strdup(cm_rtpbcast_settings.hostname)));
 	json_object_set_new(video, "port", json_integer(src->port[VIDEO]));
-	json_object_set_new(video, "host", (cm_rtpbcast_settings.hostname) ? json_string(g_strdup(cm_rtpbcast_settings.hostname)) : json_null());
+	json_object_set_new(video, "host", json_string(g_strdup(cm_rtpbcast_settings.hostname)));
 	json_object_set_new(v, "audio", audio);
 	json_object_set_new(v, "video", video);
 

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2870,7 +2870,7 @@ static void cm_rtpbcast_stats_update(cm_rtpbcast_stats *st, gsize bytes, guint32
 		/* Updating min max */
 		if (st->cur > st->max)
 			st->max = st->cur;
-		if (st->cur < st->min || st->min == -1.0L)
+		if (st->cur < st->min || (st->min == -1.0L && st->cur != 0))
 			st->min = st->cur;
 
 		/* Estimate packet loss */

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -3466,7 +3466,7 @@ json_t *cm_rtpbcast_source_stats_to_json(cm_rtpbcast_rtp_source *src) {
 		janus_mutex_unlock(&src->stats[j].stat_mutex);
 
 		json_object_set_new(v, "bitrate", b);
-		json_object_set_new(v, "udp-loss", u);
+		json_object_set_new(v, "packet-loss", u);
 		json_object_set_new(s, lnames[j], v);
 	}
 	return s;

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2816,12 +2816,12 @@ static void cm_rtpbcast_stats_restart(cm_rtpbcast_stats *st) {
 	st->start_usec = ml;
 	st->last_avg_usec = ml;
 
-	st->min = -1;
-	st->max = -1;
-	st->cur = -1;
-	st->avg = -1;
-	st->average_loss = -1;
-	st->current_loss = -1;
+	st->min = -1.0;
+	st->max = -1.0;
+	st->cur = -1.0;
+	st->avg = -1.0;
+	st->average_loss = -1.0;
+	st->current_loss = -1.0;
 
 	janus_mutex_unlock(&st->stat_mutex);
 }
@@ -2870,7 +2870,7 @@ static void cm_rtpbcast_stats_update(cm_rtpbcast_stats *st, gsize bytes, guint32
 		/* Updating min max */
 		if (st->cur > st->max)
 			st->max = st->cur;
-		if (st->cur < st->min || st->min == 0.0L)
+		if (st->cur < st->min || st->min == -1.0L)
 			st->min = st->cur;
 
 		/* Estimate packet loss */

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -3479,17 +3479,21 @@ json_t *cm_rtpbcast_source_to_json(cm_rtpbcast_rtp_source *src, cm_rtpbcast_sess
 	json_object_set_new(v, "uid", json_string(src->mp->uid));
 	json_object_set_new(v, "index", json_integer(src->index));
 
+	json_t *rtp = json_object();
 	json_t *audio = json_object();
 	json_t *video = json_object();
 	json_object_set_new(audio, "port", json_integer(src->port[AUDIO]));
 	json_object_set_new(audio, "host", json_string(g_strdup(cm_rtpbcast_settings.hostname)));
 	json_object_set_new(video, "port", json_integer(src->port[VIDEO]));
 	json_object_set_new(video, "host", json_string(g_strdup(cm_rtpbcast_settings.hostname)));
-	json_object_set_new(v, "audio", audio);
-	json_object_set_new(v, "video", video);
+	json_object_set_new(rtp, "audio", audio);
+	json_object_set_new(rtp, "video", video);
+	json_object_set_new(v, "rtp-endpoint", rtp);
 
-	json_object_set_new(v, "listeners", json_integer(g_list_length(src->listeners)));
-	json_object_set_new(v, "waiters", json_integer(g_list_length(src->waiters)));
+	json_t *rtc = json_object();
+	json_object_set_new(rtc, "listeners", json_integer(g_list_length(src->listeners)));
+	json_object_set_new(rtc, "waiters", json_integer(g_list_length(src->waiters)));
+	json_object_set_new(v, "webrtc-endpoint", rtc);
 
 	json_object_set_new(v, "stats", cm_rtpbcast_source_stats_to_json(src));
 

--- a/test/tester.py
+++ b/test/tester.py
@@ -75,8 +75,8 @@ def create(id=mountpoint_id, session=None):
     def helper(j):
         session["ports"] = []
         for i in j["plugindata"]["data"]["stream"]["streams"]:
-            session["ports"].append(i["audioport"])
-            session["ports"].append(i["videoport"])
+            session["ports"].append(i["audio"]["port"])
+            session["ports"].append(i["video"]["port"])
     janus_cmd({ "janus": "message",
                 "transaction": "tester.py",
                 "body": {
@@ -119,15 +119,15 @@ def destroy(session=None):
                 endpoint = "/" + str(session["session_id"]) + "/" + str(session["handle_id"]))
 
 # Streaming bitrates
-videorate_min = 20000
-videorate_max = 156000
-audiorate_min = 6000
-audiorate_max = 20000
+videorate_min = 128000
+videorate_max = 512000
+audiorate_min = 16000
+audiorate_max = 64000
 
 # Various parameters feel free to change in runtime
 pattern = "ball"
 fontsize = 100
-keyframedist = 120
+keyframedist = 30
 
 
 def stream(vmin = videorate_min, vmax = videorate_max, amin = audiorate_min, amax = audiorate_max, session=None):
@@ -145,7 +145,7 @@ def stream(vmin = videorate_min, vmax = videorate_max, amin = audiorate_min, ama
             args+="    opusenc bitrate=" + str(arate) + " ! "
             args+="      rtpopuspay ! udpsink host=127.0.0.1 port=" + str(session["ports"][i*2]) + "  "
             args+="  videotestsrc pattern = '" + pattern + "' ! "
-            args+="    video/x-raw,width=320,height=240,framerate=15/1 ! "
+            args+="    video/x-raw,width=640,height=480,framerate=30/1 ! "
             args+="    videoscale ! videorate ! videoconvert ! timeoverlay ! "
             args+="    textoverlay font-desc='sans, " + str(fontsize) + "' text='Quality " + str(i) + "' !"
             args+="    vp8enc keyframe-max-dist=" + str(keyframedist) + " error-resilient=true target-bitrate=" + str(vrate) + " ! "

--- a/test/tester.py
+++ b/test/tester.py
@@ -76,6 +76,7 @@ def create(id=mountpoint_id, session=None):
     session = session or definstance
     def helper(j):
         session["ports"] = []
+        session["hosts"] = []
         for i in j["plugindata"]["data"]["stream"]["streams"]:
             session["ports"].append(i["audio"]["port"])
             session["hosts"].append(i["audio"]["host"])


### PR DESCRIPTION
When looking at the client code I noticed again this asymmetry with retrieving the janus server configuration. The hostname is configured *in the client*, while the port number is retrieved *from the server* (with the mountpoint *create* call).

I think even if we hardcode it, all this information should come from a single place. The server itself should know how it can be reached (because there's no ICE). Maybe we can configure the "public rtp hostname" in the plugin configuration, and return it with the port?

Wdyt? Do you see a good way how it can be accomplished?