### PR TITLE
Single config value for session info interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Configuration
 ; Switching interval, seconds
 ; switching_delay = 1
 
+; UDP queuing allows to pool up packets and send them from separate threads
+; Alternative is sending the packets from the thread they are received from
+; udp_relay_queue_enabled = no
+
+; Interval at which UDP relay thread should wake up and process the queue, microseconds
+; udp_relay_interval = 50000
+
 ; Log error if keyframe is not found within this amount of frames
 ; keyframe_distance_alert = 600
 

--- a/README.md
+++ b/README.md
@@ -39,15 +39,14 @@ Configuration
 ; minport = 8000
 ; maxport = 9000
 
-; Source bitrate averaging interval, seconds
-; source_avg_time = 10
+; Source bitrate averaging interval and
+; session streams status update interval, seconds
+; mountpoint_info_interval = 10
+
 ; Watcher REMB averageing interval, seconds
 ; remb_avg_time = 3
 ; Switching interval, seconds
 ; switching_delay = 1
-
-; Session streams status update interval, seconds
-; session_info_update_time = 10
 
 ; Log error if keyframe is not found within this amount of frames
 ; keyframe_distance_alert = 600

--- a/README.md
+++ b/README.md
@@ -143,8 +143,7 @@ The response for multiple actions contains the `stream-definition` like follows:
 - `id` is the mountpoint identification
 - `index` is position of stream in the mountpoint/streams array
 - `session` is set only for `list` action and reference to current connection/session
-- `packet-loss/cur` is an estimate of UDP packets loss for the window of last `source_avg_time` seconds as regular stats
-- `packet-loss/avg` is an estimate of UDP packets loss for the whole time the connection is on
+- `packet-loss` is an estimate of UDP packets loss for the window of last `mountpoint_info_interval` seconds as regular stats
 
 #### Mountpoint definition for responses
 The response for multiple actions contains the `mountpoint-definition` like follows:
@@ -483,6 +482,8 @@ used for calculating statistics.
   }
 }
 ```
+- `source_avg_duration` is equal to `mountpoint_info_interval` of config file.
+- `remb_avg_duration` is equal to `remb_avg_time` of config file.
 
 #### Mountpoints information event
 It sends updates with current state of mountpoints to the `superuser` sessions. This is currently triggerd by `create` and `destroy` end point. 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Configuration
 ; mountpoint_info_interval = 10
 
 ; Watcher REMB averageing interval, seconds
-; remb_avg_time = 3
+; remb_avg_interval = 3
 ; Switching interval, seconds
 ; switching_delay = 1
 
@@ -476,14 +476,14 @@ used for calculating statistics.
       "<stream-definition-N>",
     ],
     "config": {
-      "source_avg_duration": "<int>",
-      "remb_avg_duration": "<int>"
+      "mountpoint-info-interval": "<int>",
+      "remb-avg-interval": "<int>"
     }
   }
 }
 ```
-- `source_avg_duration` is equal to `mountpoint_info_interval` of config file.
-- `remb_avg_duration` is equal to `remb_avg_time` of config file.
+- `mountpoint-info-interval` is equal to `mountpoint_info_interval` of config file.
+- `remb-avg-interval` is equal to `remb_avg_interval` of config file.
 
 #### Mountpoints information event
 It sends updates with current state of mountpoints to the `superuser` sessions. This is currently triggerd by `create` and `destroy` end point. 

--- a/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
+++ b/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
@@ -6,15 +6,14 @@
 ; minport = 8000
 ; maxport = 9000
 
-; Source bitrate averaging interval, seconds
-; source_avg_time = 10
+; Source bitrate averaging interval and
+; session streams status update interval, seconds
+; mountpoint_info_interval = 10
+
 ; Watcher REMB averageing interval, seconds
-; remb_avg_time = 3
+; remb_avg_interval = 3
 ; Switching interval, seconds
 ; switching_delay = 1
-
-; Session streams status update interval, seconds
-; session_info_update_time = 10
 
 ; UDP queuing allows to pool up packets and send them from separate threads
 ; Alternative is sending the packets from the thread they are received from

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -239,7 +239,7 @@ static struct {
 	guint thumbnailing_interval;
 	guint thumbnailing_duration;
 	guint mountpoint_info_interval;
-	guint remb_avg_time;
+	guint remb_avg_interval;
 	guint switching_delay;
 	guint keyframe_distance_alert;
 	guint udp_relay_interval;
@@ -687,8 +687,8 @@ void *cm_rtpbcast_watchdog(void *data) {
 						json_object_set_new(result, "streams", st);
 
 						json_t *config = json_object();
-						json_object_set_new(config, "source_avg_duration", json_integer(cm_rtpbcast_settings.mountpoint_info_interval));
-						json_object_set_new(config, "remb_avg_duration", json_integer(cm_rtpbcast_settings.remb_avg_time));
+						json_object_set_new(config, "mountpoint-info-interval", json_integer(cm_rtpbcast_settings.mountpoint_info_interval));
+						json_object_set_new(config, "remb-avg-interval", json_integer(cm_rtpbcast_settings.remb_avg_interval));
 						json_object_set_new(result, "config", config);
 
 						json_object_set_new(event, "result", result);
@@ -757,7 +757,7 @@ int cm_rtpbcast_init(janus_callbacks *callback, const char *config_path) {
 	cm_rtpbcast_settings.minport = 8000;
 	cm_rtpbcast_settings.maxport = 9000;
 	cm_rtpbcast_settings.mountpoint_info_interval = 10;
-	cm_rtpbcast_settings.remb_avg_time = 3;
+	cm_rtpbcast_settings.remb_avg_interval = 3;
 	cm_rtpbcast_settings.switching_delay = 1;
 	cm_rtpbcast_settings.udp_relay_interval = 50000;
 	cm_rtpbcast_settings.job_path = g_strdup("/tmp/jobs");
@@ -809,7 +809,7 @@ int cm_rtpbcast_init(janus_callbacks *callback, const char *config_path) {
 				"thumbnailing_interval",
 				"thumbnailing_duration",
 				"mountpoint_info_interval",
-				"remb_avg_time",
+				"remb_avg_interval",
 				"switching_delay",
 				"keyframe_distance_alert",
 				"packet_loss_rate",
@@ -821,7 +821,7 @@ int cm_rtpbcast_init(janus_callbacks *callback, const char *config_path) {
 				&cm_rtpbcast_settings.thumbnailing_interval,
 				&cm_rtpbcast_settings.thumbnailing_duration,
 				&cm_rtpbcast_settings.mountpoint_info_interval,
-				&cm_rtpbcast_settings.remb_avg_time,
+				&cm_rtpbcast_settings.remb_avg_interval,
 				&cm_rtpbcast_settings.switching_delay,
 				&cm_rtpbcast_settings.keyframe_distance_alert,
 				&cm_rtpbcast_settings.packet_loss_rate,
@@ -1609,7 +1609,7 @@ void cm_rtpbcast_incoming_rtcp(janus_plugin_session *handle, int video, char *bu
 		if (!sessid->last_remb_usec) {
 			sessid->last_remb_usec = ml;
 		/* Otherwise check if we stepped out */
-		} else if (ml - sessid->last_remb_usec >= cm_rtpbcast_settings.remb_avg_time * STAT_SECOND) {
+		} else if (ml - sessid->last_remb_usec >= cm_rtpbcast_settings.remb_avg_interval * STAT_SECOND) {
 			/* Calculate average */
 			sessid->remb = sessid->rembcount? sessid->rembsum / sessid->rembcount : 0;
 

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -238,10 +238,9 @@ static struct {
 	const char *thumbnailing_pattern;
 	guint thumbnailing_interval;
 	guint thumbnailing_duration;
-	guint source_avg_time;
+	guint mountpoint_info_interval;
 	guint remb_avg_time;
 	guint switching_delay;
-	guint session_info_update_time;
 	guint keyframe_distance_alert;
 	guint udp_relay_interval;
 	gboolean recording_enabled;
@@ -667,7 +666,7 @@ void *cm_rtpbcast_watchdog(void *data) {
 			}
 		}
 
-		if (now-session_update >= cm_rtpbcast_settings.session_info_update_time * G_USEC_PER_SEC) {
+		if (now-session_update >= cm_rtpbcast_settings.mountpoint_info_interval * G_USEC_PER_SEC) {
 			if(sessions && g_hash_table_size(sessions) > 0) {
 				GHashTableIter iter;
 				gpointer value;
@@ -688,7 +687,7 @@ void *cm_rtpbcast_watchdog(void *data) {
 						json_object_set_new(result, "streams", st);
 
 						json_t *config = json_object();
-						json_object_set_new(config, "source_avg_duration", json_integer(cm_rtpbcast_settings.source_avg_time));
+						json_object_set_new(config, "source_avg_duration", json_integer(cm_rtpbcast_settings.mountpoint_info_interval));
 						json_object_set_new(config, "remb_avg_duration", json_integer(cm_rtpbcast_settings.remb_avg_time));
 						json_object_set_new(result, "config", config);
 
@@ -757,10 +756,9 @@ int cm_rtpbcast_init(janus_callbacks *callback, const char *config_path) {
 	cm_rtpbcast_settings.hostname = g_strdup("localhost");
 	cm_rtpbcast_settings.minport = 8000;
 	cm_rtpbcast_settings.maxport = 9000;
-	cm_rtpbcast_settings.source_avg_time = 10;
+	cm_rtpbcast_settings.mountpoint_info_interval = 10;
 	cm_rtpbcast_settings.remb_avg_time = 3;
 	cm_rtpbcast_settings.switching_delay = 1;
-	cm_rtpbcast_settings.session_info_update_time = 10;
 	cm_rtpbcast_settings.udp_relay_interval = 50000;
 	cm_rtpbcast_settings.job_path = g_strdup("/tmp/jobs");
 	cm_rtpbcast_settings.job_pattern = g_strdup("job-#{md5}");
@@ -810,10 +808,9 @@ int cm_rtpbcast_init(janus_callbacks *callback, const char *config_path) {
 				"maxport",
 				"thumbnailing_interval",
 				"thumbnailing_duration",
-				"source_avg_time",
+				"mountpoint_info_interval",
 				"remb_avg_time",
 				"switching_delay",
-				"session_info_update_time",
 				"keyframe_distance_alert",
 				"packet_loss_rate",
 				"udp_relay_interval",
@@ -823,10 +820,9 @@ int cm_rtpbcast_init(janus_callbacks *callback, const char *config_path) {
 				&cm_rtpbcast_settings.maxport,
 				&cm_rtpbcast_settings.thumbnailing_interval,
 				&cm_rtpbcast_settings.thumbnailing_duration,
-				&cm_rtpbcast_settings.source_avg_time,
+				&cm_rtpbcast_settings.mountpoint_info_interval,
 				&cm_rtpbcast_settings.remb_avg_time,
 				&cm_rtpbcast_settings.switching_delay,
-				&cm_rtpbcast_settings.session_info_update_time,
 				&cm_rtpbcast_settings.keyframe_distance_alert,
 				&cm_rtpbcast_settings.packet_loss_rate,
 				&cm_rtpbcast_settings.udp_relay_interval,
@@ -2853,7 +2849,7 @@ static void cm_rtpbcast_stats_update(cm_rtpbcast_stats *st, gsize bytes, guint32
 	guint64 delay;
 
 	/* If we step over delay, calculate current and compare min/max */
-	if (ml - st->last_avg_usec >= cm_rtpbcast_settings.source_avg_time * STAT_SECOND) {
+	if (ml - st->last_avg_usec >= cm_rtpbcast_settings.mountpoint_info_interval * STAT_SECOND) {
 		/* Calculate */
 		delay = ml - st->last_avg_usec;
 		st->cur = (8.0L*10e5L)*(gdouble)st->bytes_since_last_avg / (delay != 0 ? delay : 1);


### PR DESCRIPTION
Currently we send the session info every `session_info_update_time` seconds, and it is averaged over `source_avg_time`. I would suggest to combine the two into 1 value.

Then on the client we can just store the average whenever we receive it, and average again over those averages if desired.

cc @zazabe