### PR TITLE
rtpbroadcast dies on development VM

### DIFF
--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -3223,7 +3223,7 @@ void cm_rtpbcast_mountpoint_destroy(gpointer data, gpointer user_data) {
 		}
 
 		/* If it's recording, stop it */
-		if(mp->rc[AUDIO]->r || mp->rc[VIDEO]->r)
+		if(mp->rc[AUDIO] && mp->rc[AUDIO]->r || mp->rc[VIDEO] && mp->rc[VIDEO]->r)
 			cm_rtpbcast_stop_recording(mp, 0);
 
 		if(mp->trc[0] && mp->trc[0]->r)


### PR DESCRIPTION
Last message is always "Timeout expired for session":
```
[Thu Apr 14 13:53:47 2016] [hvu39xGoT9Aoir4MqtbI0w__] New audio stream! (ssrc=4259405333)
[Thu Apr 14 13:53:47 2016] [hvu39xGoT9Aoir4MqtbI0w__] New audio stream! (ssrc=212122636)
[Thu Apr 14 13:53:47 2016] [hvu39xGoT9Aoir4MqtbI0w__] New video stream! (ssrc=3188504535)
[Thu Apr 14 13:53:50 2016] Creating new handle in session 1616202850: 3328866235
[Thu Apr 14 13:53:50 2016] [3328866235] Creating ICE agent (ICE Full mode, controlling)
[Thu Apr 14 13:53:50 2016] [3328866235] The DTLS handshake has been completed
[Thu Apr 14 13:53:50 2016] WebRTC media is now available
[Thu Apr 14 13:54:10 2016] [WSS-0xfc6000] Destroying WebSocket client
[Thu Apr 14 13:54:11 2016] Timeout expired for session 2681868537...
````