### PR TITLE
janus rtpbroadcast: check packet loss metric

### DIFF
--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2841,11 +2841,8 @@ static void cm_rtpbcast_stats_update(cm_rtpbcast_stats *st, gsize bytes, guint32
 		}
 
 		/* Reset mas stored sequence number on overflow */
-		if (seq == 65535) {
-			st->max_seq_since_last_avg = 0;
-			st->last_avg_seq = 0;
-			st->packets_since_last_avg = 0;
-		}
+		if (seq == 65535)
+			st->max_seq_since_last_avg = st->last_avg_seq = st->packets_since_last_avg = 0;
 
 		/* Make sure to count the biggest seq number we've seen in this
 		 * averaging interval to counter reordering */
@@ -2855,9 +2852,8 @@ static void cm_rtpbcast_stats_update(cm_rtpbcast_stats *st, gsize bytes, guint32
 		/* Make sure that we reset the max stored sequence number if the
 		 * overflows occurs. This is double check mechanism. */
 		if (st->max_seq_since_last_avg > seq) {
-			st->max_seq_since_last_avg = seq;
-			st->last_avg_seq = 0;
-			st->packets_since_last_avg = seq;
+			st->max_seq_since_last_avg = st->packets_since_last_avg = seq;
+			st->last_avg_seq = 0;Formatting
 		}
 	}
 

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2840,7 +2840,7 @@ static void cm_rtpbcast_stats_update(cm_rtpbcast_stats *st, gsize bytes, guint32
 				st->packets_since_last_avg++;
 		}
 
-		/* Reset mas stored sequence number on overflow */
+		/* Reset max sequence number stored on overflow */
 		if (seq == 65535)
 			st->max_seq_since_last_avg = st->last_avg_seq = st->packets_since_last_avg = 0;
 
@@ -2850,7 +2850,7 @@ static void cm_rtpbcast_stats_update(cm_rtpbcast_stats *st, gsize bytes, guint32
 			st->max_seq_since_last_avg = seq;
 
 		/* Make sure that we reset the max stored sequence number if the
-		 * overflows occurs. This is double check mechanism. */
+		 * overflows occurs. This is double check mechanism if 65535 is lost. */
 		if (st->max_seq_since_last_avg > seq) {
 			st->max_seq_since_last_avg = st->packets_since_last_avg = seq;
 			st->last_avg_seq = 0;

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2839,9 +2839,19 @@ static void cm_rtpbcast_stats_update(cm_rtpbcast_stats *st, gsize bytes, guint32
 			if (seq >= st->last_avg_seq)
 				st->packets_since_last_avg++;
 		}
+
+		/* Reset mas stored sequence number on overflow */
+		if (st->max_seq_since_last_avg == 65535)
+			st->max_seq_since_last_avg = 0;
+
 		/* Make sure to count the biggest seq number we've seen in this
 		 * averaging interval to counter reordering */
 		if (st->max_seq_since_last_avg < seq)
+			st->max_seq_since_last_avg = seq;
+
+		/* Make sure that we reset the max stored sequence number if the
+		 * overflows occurs. This is double check mechanism. */
+		if (st->max_seq_since_last_avg > seq)
 			st->max_seq_since_last_avg = seq;
 	}
 

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2853,7 +2853,7 @@ static void cm_rtpbcast_stats_update(cm_rtpbcast_stats *st, gsize bytes, guint32
 		 * overflows occurs. This is double check mechanism. */
 		if (st->max_seq_since_last_avg > seq) {
 			st->max_seq_since_last_avg = st->packets_since_last_avg = seq;
-			st->last_avg_seq = 0;Formatting
+			st->last_avg_seq = 0;
 		}
 	}
 

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2841,8 +2841,11 @@ static void cm_rtpbcast_stats_update(cm_rtpbcast_stats *st, gsize bytes, guint32
 		}
 
 		/* Reset mas stored sequence number on overflow */
-		if (st->max_seq_since_last_avg == 65535)
+		if (seq == 65535) {
 			st->max_seq_since_last_avg = 0;
+			st->last_avg_seq = 0;
+			st->packets_since_last_avg = 0;
+		}
 
 		/* Make sure to count the biggest seq number we've seen in this
 		 * averaging interval to counter reordering */
@@ -2851,8 +2854,11 @@ static void cm_rtpbcast_stats_update(cm_rtpbcast_stats *st, gsize bytes, guint32
 
 		/* Make sure that we reset the max stored sequence number if the
 		 * overflows occurs. This is double check mechanism. */
-		if (st->max_seq_since_last_avg > seq)
+		if (st->max_seq_since_last_avg > seq) {
 			st->max_seq_since_last_avg = seq;
+			st->last_avg_seq = 0;
+			st->packets_since_last_avg = seq;
+		}
 	}
 
 	guint64 ml = janus_get_monotonic_time();
@@ -2870,8 +2876,8 @@ static void cm_rtpbcast_stats_update(cm_rtpbcast_stats *st, gsize bytes, guint32
 
 		/* Estimate packet loss */
 		if (isvideo != -1) {
-			guint32 den = st->max_seq_since_last_avg - st->last_avg_seq + 1;
-			if (den != 0)
+			guint32 den = st->max_seq_since_last_avg - st->last_avg_seq;
+			if (den != 0 && st->packets_since_last_avg < den)
 				st->current_loss = 1.0 - (gdouble)st->packets_since_last_avg / (gdouble) den;
 			else
 				st->current_loss = 0.0;
@@ -2885,7 +2891,7 @@ static void cm_rtpbcast_stats_update(cm_rtpbcast_stats *st, gsize bytes, guint32
 	/* Re-calculate average regardless */
 	if (isvideo != -1) {
 		guint32 den = st->max_seq_since_last_avg - st->start_seq + 1;
-		if (den != 0)
+		if (den != 0 && st->packets_since_start < den)
 			st->average_loss = 1.0 - (gdouble)st->packets_since_start / (gdouble) den;
 		else
 			st->average_loss = 0.0;


### PR DESCRIPTION
<img width="581" alt="screen shot 2016-05-06 at 01 05 02" src="https://cloud.githubusercontent.com/assets/360800/15059927/9bb63b2e-1326-11e6-8bf2-c39359a84980.png">
<img width="577" alt="screen shot 2016-05-06 at 01 05 10" src="https://cloud.githubusercontent.com/assets/360800/15059928/9bb8e27a-1326-11e6-90a8-be1a86b7d1e6.png">

"packet-loss" value "1" is reported over WebSocket, so probably a problem in the rtpbroadcast plugin.
