### PR TITLE
Remove averaging and delay of auto-switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The response for multiple actions contains the `stream-definition` like follows:
    "session": {
       "webrtc-active": "<boolean>",
       "autoswitch-enabled": "<boolean>",
-      "remb-avg": "<int|null>"
+      "remb": "<int|null>"
    }
 }
 ```
@@ -479,13 +479,11 @@ used for calculating statistics.
     ],
     "config": {
       "mountpoint-info-interval": "<int>",
-      "remb-avg-interval": "<int>"
     }
   }
 }
 ```
 - `mountpoint-info-interval` is equal to `mountpoint_info_interval` of config file.
-- `remb-avg-interval` is equal to `remb_avg_interval` of config file.
 
 #### Mountpoints information event
 It sends updates with current state of mountpoints to the `superuser` sessions. This is currently triggerd by `create` and `destroy` end point. 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ Configuration
 ; session streams status update interval, seconds
 ; mountpoint_info_interval = 10
 
-; Watcher REMB averageing interval, seconds
-; remb_avg_interval = 3
 ; Switching interval, seconds
 ; switching_delay = 1
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,6 @@ Configuration
 ; session streams status update interval, seconds
 ; mountpoint_info_interval = 10
 
-; Switching interval, seconds
-; switching_delay = 1
-
 ; UDP queuing allows to pool up packets and send them from separate threads
 ; Alternative is sending the packets from the thread they are received from
 ; udp_relay_queue_enabled = no

--- a/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
+++ b/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
@@ -10,8 +10,6 @@
 ; session streams status update interval, seconds
 ; mountpoint_info_interval = 10
 
-; Watcher REMB averageing interval, seconds
-; remb_avg_interval = 3
 ; Switching interval, seconds
 ; switching_delay = 1
 

--- a/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
+++ b/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
@@ -10,9 +10,6 @@
 ; session streams status update interval, seconds
 ; mountpoint_info_interval = 10
 
-; Switching interval, seconds
-; switching_delay = 1
-
 ; UDP queuing allows to pool up packets and send them from separate threads
 ; Alternative is sending the packets from the thread they are received from
 ; udp_relay_queue_enabled = no

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -1601,7 +1601,6 @@ void cm_rtpbcast_incoming_rtcp(janus_plugin_session *handle, int video, char *bu
 
 		/* If the session is watching something, let's see if it needs switching */
 		if (sessid->source &&
-				oldremb != sessid->remb && sessid->remb != 0 &&
 					ml - sessid->last_switch >= cm_rtpbcast_settings.switching_delay * STAT_SECOND ) {
 
 			if (sessid->source == NULL)

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -3473,7 +3473,7 @@ json_t *cm_rtpbcast_source_to_json(cm_rtpbcast_rtp_source *src, cm_rtpbcast_sess
 	json_t *u = json_object();
 	json_object_set_new(u, "webrtc-active", json_integer(session->source == src));
 	json_object_set_new(u, "autoswitch-enabled", json_integer(session->autoswitch));
-	json_object_set_new(u, "remb-avg", (session->remb == -1)? json_null() : json_integer(session->remb));
+	json_object_set_new(u, "remb", (session->remb == -1)? json_null() : json_integer(session->remb));
 	json_object_set_new(v, "session", u);
 
 	return v;

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -239,7 +239,6 @@ static struct {
 	guint thumbnailing_interval;
 	guint thumbnailing_duration;
 	guint mountpoint_info_interval;
-	guint switching_delay;
 	guint keyframe_distance_alert;
 	guint udp_relay_interval;
 	gboolean recording_enabled;
@@ -753,7 +752,6 @@ int cm_rtpbcast_init(janus_callbacks *callback, const char *config_path) {
 	cm_rtpbcast_settings.minport = 8000;
 	cm_rtpbcast_settings.maxport = 9000;
 	cm_rtpbcast_settings.mountpoint_info_interval = 10;
-	cm_rtpbcast_settings.switching_delay = 1;
 	cm_rtpbcast_settings.udp_relay_interval = 50000;
 	cm_rtpbcast_settings.job_path = g_strdup("/tmp/jobs");
 	cm_rtpbcast_settings.job_pattern = g_strdup("job-#{md5}");
@@ -804,7 +802,6 @@ int cm_rtpbcast_init(janus_callbacks *callback, const char *config_path) {
 				"thumbnailing_interval",
 				"thumbnailing_duration",
 				"mountpoint_info_interval",
-				"switching_delay",
 				"keyframe_distance_alert",
 				"packet_loss_rate",
 				"udp_relay_interval",
@@ -815,7 +812,6 @@ int cm_rtpbcast_init(janus_callbacks *callback, const char *config_path) {
 				&cm_rtpbcast_settings.thumbnailing_interval,
 				&cm_rtpbcast_settings.thumbnailing_duration,
 				&cm_rtpbcast_settings.mountpoint_info_interval,
-				&cm_rtpbcast_settings.switching_delay,
 				&cm_rtpbcast_settings.keyframe_distance_alert,
 				&cm_rtpbcast_settings.packet_loss_rate,
 				&cm_rtpbcast_settings.udp_relay_interval,
@@ -1600,8 +1596,7 @@ void cm_rtpbcast_incoming_rtcp(janus_plugin_session *handle, int video, char *bu
 		sessid->last_remb_usec = ml;
 
 		/* If the session is watching something, let's see if it needs switching */
-		if (sessid->source &&
-					ml - sessid->last_switch >= cm_rtpbcast_settings.switching_delay * STAT_SECOND ) {
+		if (sessid->source) {
 
 			if (sessid->source == NULL)
 				return;


### PR DESCRIPTION
Part of https://github.com/cargomedia/sk/issues/2891

Because we can trust the client to do the correct timing and calculation.
This is also what I experienced during my tests.
Reference: https://tools.ietf.org/html/draft-alvestrand-rtcweb-congestion-03

```
; Watcher REMB averageing interval, seconds
; remb_avg_interval = 3
; Switching interval, seconds
; switching_delay = 1
```

@kris-lab wdyt?
cc @zazabe 