### PR TITLE
Fixes for pick-up the right stream based on REMB

### DIFF
--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -1580,9 +1580,6 @@ void cm_rtpbcast_incoming_rtcp(janus_plugin_session *handle, int video, char *bu
 	if (sessid->stopping || sessid->paused)
 		return;
 
-	if (!sessid->autoswitch)
-		return;
-
 	/* We might interested in the available bandwidth that the user advertizes */
 	uint64_t bw = janus_rtcp_get_remb(buf, len);
 	if(bw > 0) {
@@ -1596,7 +1593,7 @@ void cm_rtpbcast_incoming_rtcp(janus_plugin_session *handle, int video, char *bu
 		sessid->last_remb_usec = ml;
 
 		/* If the session is watching something, let's see if it needs switching */
-		if (sessid->source) {
+		if (sessid->source && sessid->autoswitch) {
 
 			if (sessid->source == NULL)
 				return;

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2897,11 +2897,11 @@ cm_rtpbcast_rtp_source* cm_rtpbcast_pick_source(GArray *sources, guint64 remb) {
 		}
 	}
 
- if (best_src == NULL) {
+	if (best_src == NULL) {
 		if (sources != NULL) {
 			best_src = g_array_index(sources, cm_rtpbcast_rtp_source *, (sources->len-1));
 		}
-  }
+	}
 
 	return best_src;
 }

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2886,16 +2886,22 @@ cm_rtpbcast_rtp_source* cm_rtpbcast_pick_source(GArray *sources, guint64 remb) {
 		 no such source found */
 	guint i; cm_rtpbcast_rtp_source *src, *best_src = NULL; guint64 best_bw = 0, source_bw;
 	for (i = 0; i < sources->len; i++) {
-		src = g_array_index(sources, cm_rtpbcast_rtp_source *, i++);
+		src = g_array_index(sources, cm_rtpbcast_rtp_source *, i);
 		janus_mutex_lock(&src->stats[VIDEO].stat_mutex);
 		source_bw = (guint64)src->stats[VIDEO].cur;
 		janus_mutex_unlock(&src->stats[VIDEO].stat_mutex);
 
-		if (!best_bw || (best_bw < source_bw && source_bw < remb )) {
+		if ((source_bw < remb) && !best_bw) {
 			best_src = src;
 			best_bw = source_bw;
 		}
 	}
+
+ if (best_src == NULL) {
+		if (sources != NULL) {
+			best_src = g_array_index(sources, cm_rtpbcast_rtp_source *, (sources->len-1));
+		}
+  }
 
 	return best_src;
 }

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2878,10 +2878,6 @@ cm_rtpbcast_rtp_source* cm_rtpbcast_pick_source(GArray *sources, guint64 remb) {
 	if (sources->len <= 0)
 		return NULL;
 
-	/* If we don't know the remb yet, return highest quality stream */
-	if (remb == 0)
-		return g_array_index(sources, cm_rtpbcast_rtp_source *, 0);
-
 	/* Pick the source with bitrate less than REMB given or the worst quality if
 		 no such source found */
 	guint i; cm_rtpbcast_rtp_source *src, *best_src = NULL; guint64 best_bw = 0, source_bw;

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2898,9 +2898,7 @@ cm_rtpbcast_rtp_source* cm_rtpbcast_pick_source(GArray *sources, guint64 remb) {
 	}
 
 	if (best_src == NULL) {
-		if (sources != NULL) {
-			best_src = g_array_index(sources, cm_rtpbcast_rtp_source *, (sources->len-1));
-		}
+		best_src = g_array_index(sources, cm_rtpbcast_rtp_source *, (sources->len-1));
 	}
 
 	return best_src;


### PR DESCRIPTION
As investigated with @zazabe there are some bugs in the `cm_rtpbcast_pick_source`.

Also see related: https://github.com/cargomedia/janus-gateway-rtpbroadcast/issues/91