### PR TITLE
Packet loss count not resetting correctly?

### DIFF
--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2818,7 +2818,7 @@ static void cm_rtpbcast_stats_update(cm_rtpbcast_stats *st, gsize bytes, guint32
 
 		/* Reset max sequence number stored on overflow */
 		if (seq == 65535)
-			st->max_seq_since_last_avg = st->last_avg_seq = st->packets_since_last_avg = 0;
+			st->max_seq_since_last_avg = st->last_avg_seq = st->packets_since_last_avg = seq = 0;
 
 		/* Make sure to count the biggest seq number we've seen in this
 		 * averaging interval to counter reordering */


### PR DESCRIPTION
Note the value is 65535:
![screen shot 2016-06-14 at 13 00 24](https://cloud.githubusercontent.com/assets/360800/16040489/0e7f18c4-3230-11e6-8e37-f4f6200a0699.png)