### PR TITLE
"switchSource" response with same data than "mountpoint-info" event

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The response for multiple actions contains the `stream-definition` like follows:
       "key-distance": "<int>"
    },
    "session": {
-      "webrtc-active": "<boolean>",
+      "webrtc-status": "<string|null>",
       "autoswitch-enabled": "<boolean>",
       "remb": "<int|null>"
    }
@@ -141,6 +141,7 @@ The response for multiple actions contains the `stream-definition` like follows:
 - `session` is set only for `list` action and reference to current connection/session
 - `packet-loss-rate` is an estimated rate of UDP packet loss for the window of last `mountpoint_info_interval` seconds as regular stats
 - `packet-loss-count` is a count of UDP packets lost for a lifetime of the stream
+- `webrtc-status` if defined can be "active" or "next"
 
 #### Mountpoint definition for responses
 The response for multiple actions contains the `mountpoint-definition` like follows:
@@ -366,14 +367,15 @@ If `index` is equal to `0` then `auto-switch` support will be `ON`.
 {
   "streaming": "event",
   "result": {
-    "next": "null|<stream-definition>",
-    "current": "<stream-definition>",
-    "autoswitch": "<boolean>"
+    "streams": [
+      "<stream-definition-1>",
+      "<stream-definition-2>",
+      "<stream-definition-N>",
+    ],
   }
 }
 ```
 
-`next` source definition is not available if `autoswitch` is set to `true`.
 
 #### `superuser`
 By passing `true` it upgrades current session into super user session and downgrade into regular one by passing `false`.
@@ -503,8 +505,11 @@ If scheduled task is executed the subscriber receives media event:
   "streaming": "event",
   "result": {
     "event": "changed",
-    "current": "<stream-definition>",
-    "previous": "<stream-definition>"
+    "streams": [
+      "<stream-definition-1>",
+      "<stream-definition-2>",
+      "<stream-definition-N>",
+    ],
   }
 }
 ```

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -1995,8 +1995,8 @@ static void *cm_rtpbcast_handler(void *data) {
 				session->autoswitch = cm_rtpbcast_settings.autoswitch;
 			}
 			/* Done */
-			json_t *sources = cm_rtpbcast_sources_to_json(session->source->mp->sources, session);
-			json_object_set_new(result, "streams", sources);
+			json_t *streams = cm_rtpbcast_sources_to_json(session->source->mp->sources, session);
+			json_object_set_new(result, "streams", streams);
 		} else if(!strcasecmp(request_text, "switch")) {
 			/* This listener wants to switch to a different mountpoint
 			 * NOTE: this only works for live RTP streams as of now: you
@@ -3374,8 +3374,8 @@ static void cm_rtpbcast_execute_switching(gpointer data, gpointer user_data) {
 
 	json_object_set_new(result, "event", json_string("changed"));
 
-	json_t *st = cm_rtpbcast_sources_to_json(source->mp->sources, sessid);
-	json_object_set_new(result, "streams", st);
+	json_t *streams = cm_rtpbcast_sources_to_json(source->mp->sources, sessid);
+	json_object_set_new(result, "streams", streams);
 
 	json_object_set_new(event, "result", result);
 	char *event_text = json_dumps(event, JSON_INDENT(3) | JSON_PRESERVE_ORDER);

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -3374,11 +3374,8 @@ static void cm_rtpbcast_execute_switching(gpointer data, gpointer user_data) {
 
 	json_object_set_new(result, "event", json_string("changed"));
 
-	json_t *currentsrc = cm_rtpbcast_source_to_json(source, sessid);
-	json_t *previoussrc = cm_rtpbcast_source_to_json(oldsrc, sessid);
-
-	json_object_set_new(result, "current", currentsrc);
-	json_object_set_new(result, "previous", previoussrc);
+	json_t *st = cm_rtpbcast_sources_to_json(source->mp->sources, sessid);
+	json_object_set_new(result, "streams", st);
 
 	json_object_set_new(event, "result", result);
 	char *event_text = json_dumps(event, JSON_INDENT(3) | JSON_PRESERVE_ORDER);


### PR DESCRIPTION
On the client side, it would be nice to receive the same data than `mountpoint-info` instead of `{autoswitch: 0, current: {...}, next: {...}}`.
