### PR TITLE
Make sure we do not create "thumbnails" while RTP packets lost occurred

### DIFF
--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2613,13 +2613,10 @@ static void *cm_rtpbcast_relay_thread(void *data) {
 							guint32 den = source->stats[j].max_seq_since_last_avg - source->stats[j].last_avg_seq;
 							/* If any packet received, let's check if all packets arrived based on sequence number */
 							if (den != 0 && source->stats[j].packets_since_last_avg < den) {
-								/* If any packet has been lost then let's assume the keyframe is corrupted */
-								if((den - source->stats[j].packets_since_last_avg) > 0) {
-									/* Mark the keyframe for current thumbnail record as corrupted */
-									mountpoint->trc[0]->had_keyframe = FALSE;
-									/* Force the restart of thumbnail record */
-									mountpoint->last_thumbnail = 0;
-								}
+								/* Mark the keyframe for current thumbnailing record as corrupted */
+								mountpoint->trc[0]->had_keyframe = FALSE;
+								/* Force the restart of thumbnailing record */
+								mountpoint->last_thumbnail = 0;
 							}
 							cm_rtpbcast_stop_thumbnailing(mountpoint, 0);
 						}

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2608,8 +2608,19 @@ static void *cm_rtpbcast_relay_thread(void *data) {
 							janus_recorder_save_frame(mountpoint->trc[0]->r, buffer, bytes);
 
 						/* Is it time to stop the thumbnailing? */
-						if (mountpoint->trc[0]->r && (ml > mountpoint->last_thumbnail
-							+ cm_rtpbcast_settings.thumbnailing_duration * 1000000)) {
+						if (mountpoint->trc[0]->r && (ml > mountpoint->last_thumbnail + cm_rtpbcast_settings.thumbnailing_duration * 1000000)) {
+							/* Packets density since last source/stats average */
+							guint32 den = source->stats[j].max_seq_since_last_avg - source->stats[j].last_avg_seq;
+							/* If any packet received, let's check if all packets arrived based on sequence number */
+							if (den != 0 && source->stats[j].packets_since_last_avg < den) {
+								/* If any packet has been lost then let's assume the keyframe is corrupted */
+								if((den - source->stats[j].packets_since_last_avg) > 0) {
+									/* This is assumption that keyframe is cirrupted if any packet has been lost during recording */
+									mountpoint->trc[0]->had_keyframe = FALSE;
+									/* Force the restart of thumbnailing record */
+									mountpoint->last_thumbnail = 0;
+								}
+							}
 							cm_rtpbcast_stop_thumbnailing(mountpoint, 0);
 						}
 					}

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2615,9 +2615,9 @@ static void *cm_rtpbcast_relay_thread(void *data) {
 							if (den != 0 && source->stats[j].packets_since_last_avg < den) {
 								/* If any packet has been lost then let's assume the keyframe is corrupted */
 								if((den - source->stats[j].packets_since_last_avg) > 0) {
-									/* This is assumption that keyframe is cirrupted if any packet has been lost during recording */
+									/* Mark the keyframe for current thumbnail record as corrupted */
 									mountpoint->trc[0]->had_keyframe = FALSE;
-									/* Force the restart of thumbnailing record */
+									/* Force the restart of thumbnail record */
 									mountpoint->last_thumbnail = 0;
 								}
 							}


### PR DESCRIPTION
Part of https://github.com/cargomedia/puppet-cargomedia/issues/1203
Part of https://github.com/cargomedia/puppet-cargomedia/issues/1115

(copying myself)
> - keyframe is splitted into many RTP packets: there might be a case if keyframe is made of e.g. 5 RTP packets and we detect 1st RTP packet as proper keyframe. However if following packets are corrupted (by UDP loss) there will be problem on the decode level. We should make sure that marking frame as keyframe is done only if all releated data (packets) are valid.
- not enough data arrived - freezing problem - in general we should give a track of data flow and avoid storing data (thumbs/records) if we detect UDP loss. Currently it is possible due to the metrics we collect.