### PR TITLE
Adjust "thumbnails recorder" to be resistant for packets lost

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,6 @@ Configuration
 ; Thumbnailing interval in seconds
 ; thumbnailing_interval = 60
 
-; Thumbnailing duration in seconds
-; thumbnailing_duration = 10
-
 ; Bad connection simulator, only for debug purpose
 ; Note: defaults are 0, comment the options to disable
 ; simulate_bad_connection = yes
@@ -469,7 +466,7 @@ It creates configurable `job-files` with plugin events. It support for `archive-
 ```
 
 ##### `thumbnailing-finished`
-Thumbnailer creates archives of configurable duration for configurable interval of time.
+Thumbnailer creates archives of single `keyframe` every configurable interval of time.
 
 ```json
 {

--- a/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
+++ b/conf/janus.plugin.cm.rtpbroadcast.cfg.sample
@@ -56,9 +56,6 @@
 ; Thumbnailing interval in seconds
 ; thumbnailing_interval = 60
 
-; Thumbnailing duration in seconds
-; thumbnailing_duration = 10
-
 ; Bad connection simulator, only for debug purpose
 ; Note: defaults are 0, comment the options to disable
 ; simulate_bad_connection = yes

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2715,7 +2715,9 @@ static void *cm_rtpbcast_relay_thread(void *data) {
 				/* Update all waiting sessions with new keyframe packets and upgrade them to listeners list */
 				if(is_video_keyframe) {
 					JANUS_LOG(LOG_HUGE, "[%s] Key frame on source %d\n", name, source->index);
+					janus_mutex_lock(&source->mutex);
 					GList *waiters = g_list_copy (source->waiters);
+					janus_mutex_unlock(&source->mutex);
 					if(waiters) {
 						cm_rtpbcast_process_switchers(source);
 						janus_mutex_lock(&source->keyframe.mutex);

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2688,7 +2688,6 @@ static void *cm_rtpbcast_relay_thread(void *data) {
 							cm_rtpbcast_start_thumbnailing(mountpoint, 0); /* Source at index 0 will be recorded */
 							janus_mutex_lock(&source->keyframe.mutex);
 							if(source->keyframe.latest_keyframe != NULL) {
-								JANUS_LOG(LOG_HUGE, "Yep! %d packets\n", g_list_length(source->keyframe.latest_keyframe));
 								GList *temp = source->keyframe.latest_keyframe;
 								while(temp) {
 									cm_rtpbcast_rtp_relay_packet *pkt = (cm_rtpbcast_rtp_relay_packet *)temp->data;

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2720,16 +2720,18 @@ static void *cm_rtpbcast_relay_thread(void *data) {
 					janus_mutex_unlock(&source->mutex);
 					if(waiters) {
 						cm_rtpbcast_process_switchers(source);
+						janus_mutex_lock(&source->mutex);
 						janus_mutex_lock(&source->keyframe.mutex);
 						if(source->keyframe.latest_keyframe != NULL && g_list_length(waiters)) {
 							GList *temp = source->keyframe.latest_keyframe;
 							while(temp) {
-								JANUS_LOG(LOG_INFO, "[%s] switching waiters, sending keyframe\n", name);
+								JANUS_LOG(LOG_VERB, "[%s] switching waiters, sending keyframe\n", name);
 								g_list_foreach(waiters, cm_rtpbcast_relay_rtp_packet, temp->data);
 								temp = temp->next;
 							}
 						}
 						janus_mutex_unlock(&source->keyframe.mutex);
+						janus_mutex_unlock(&source->mutex);
 					}
 					g_list_free(waiters);
 				}
@@ -3453,15 +3455,15 @@ void cm_rtpbcast_schedule_switch(cm_rtpbcast_session *sessid, cm_rtpbcast_rtp_so
 	if (ns) {
 		janus_mutex_lock(&ns->mutex);
 		ns->waiters = g_list_remove_all(ns->waiters, sessid);
-		sessid->nextsource = NULL;
 		janus_mutex_unlock(&ns->mutex);
+		sessid->nextsource = NULL;
 	}
 
 	/* Attaching to a new source */
-	sessid->nextsource = newsrc;
 	janus_mutex_lock(&newsrc->mutex);
 	newsrc->waiters = g_list_prepend(newsrc->waiters, sessid);
 	janus_mutex_unlock(&newsrc->mutex);
+	sessid->nextsource = newsrc;
 
 	janus_mutex_unlock(&sessid->mutex);
 }

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -3317,19 +3317,15 @@ char *str_replace(char *instr, const char *needle, const char *replace) {
 
 void cm_rtpbcast_mountpoint_destroy(gpointer data, gpointer user_data) {
 	cm_rtpbcast_mountpoint * mp = (cm_rtpbcast_mountpoint *) data;
-	JANUS_LOG(LOG_INFO, "destroy, -1\n");
 	if(!mp->destroyed) {
 		/* FIXME Should we kick the current viewers as well? */
 		guint i;
-		JANUS_LOG(LOG_INFO, "destroy, 0\n");
 		for (i = 0; i < mp->sources->len; i++) {
 			cm_rtpbcast_rtp_source *src = g_array_index(mp->sources,
 				cm_rtpbcast_rtp_source *, i);
 
 			janus_mutex_lock(&src->mutex);
-			JANUS_LOG(LOG_INFO, "destroy, 1\n");
 			GList *viewer = g_list_first(src->listeners);
-			JANUS_LOG(LOG_INFO, "destroy, 2\n");
 			/* Prepare JSON event */
 			json_t *event = json_object();
 			json_object_set_new(event, "streaming", json_string("event"));
@@ -3339,7 +3335,6 @@ void cm_rtpbcast_mountpoint_destroy(gpointer data, gpointer user_data) {
 			char *event_text = json_dumps(event, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
 			json_decref(event);
 			while(viewer) {
-				JANUS_LOG(LOG_INFO, "destroy, 3\n");
 				cm_rtpbcast_session *session = (cm_rtpbcast_session *)viewer->data;
 				/* TODO: why don't we have a per-session mutex? */
 				if(session != NULL) {

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2695,9 +2695,9 @@ static void *cm_rtpbcast_relay_thread(void *data) {
 					/* Is it time to do thumbnailing? */
 					guint64 ml = janus_get_monotonic_time();
 					if (!mountpoint->trc[0] && (ml > mountpoint->last_thumbnail + cm_rtpbcast_settings.thumbnailing_interval * 1000000)) {
-						cm_rtpbcast_start_thumbnailing(mountpoint, 0); /* Source at index 0 will be recorded */
 						janus_mutex_lock(&source->keyframe.mutex);
 						if(source->keyframe.latest_keyframe != NULL) {
+							cm_rtpbcast_start_thumbnailing(mountpoint, 0); /* Keyframe of source at index 0 will be stored */
 							GList *temp = source->keyframe.latest_keyframe;
 							while(temp) {
 								cm_rtpbcast_rtp_relay_packet *pkt = (cm_rtpbcast_rtp_relay_packet *)temp->data;
@@ -2705,9 +2705,9 @@ static void *cm_rtpbcast_relay_thread(void *data) {
 								temp = temp->next;
 							}
 							mountpoint->trc[0]->had_keyframe = TRUE;
+							cm_rtpbcast_stop_thumbnailing(mountpoint, 0);
 						}
 						janus_mutex_unlock(&source->keyframe.mutex);
-						cm_rtpbcast_stop_thumbnailing(mountpoint, 0);
 						mountpoint->last_thumbnail = ml;
 					}
 				}


### PR DESCRIPTION
Depends on https://github.com/cargomedia/janus-gateway-rtpbroadcast/issues/110

As reported https://github.com/cargomedia/puppet-cargomedia/issues/1347 there is possibility that thumbnail recorder is not resistant for packets lost and finally dumps RTP packets and job file even if data is corrupted. 

For records the logic has been introduced https://github.com/cargomedia/janus-gateway-rtpbroadcast/pull/102