### PR TITLE
Segfaults during stream switching - take 2

### DIFF
--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2718,11 +2718,6 @@ static void cm_rtpbcast_relay_rtp_packet(gpointer data, gpointer user_data) {
 	packet->data->timestamp = htonl(session->context.last_ts[j]);
 	packet->data->seq_number = htons(session->context.last_seq[j]);
 
-	int i=0;
-	for(i=0;i<100000000; i++) {
-		if(session->source) {}
-	}
-
 	if (session->source) {
 		if(gateway != NULL) {
 			gateway->relay_rtp(session->handle, packet->is_video, (char *)packet->data, packet->length);
@@ -3393,11 +3388,7 @@ static void cm_rtpbcast_execute_switching(gpointer data, gpointer user_data) {
 		/* Remove from old source and attach to new source */
 		oldsrc->listeners = g_list_remove_all(oldsrc->listeners, sessid);
 		source->listeners = g_list_prepend(source->listeners, sessid);
-
-		int i=0;
-		for(i=0;i<100000000; i++) {
-			sessid->source = source;
-		}
+		sessid->source = source;
 
 		JANUS_LOG(LOG_VERB, "Session 0x%x switched to source 0x%x\n", GPOINTER_TO_UINT(sessid), GPOINTER_TO_UINT(source));
 

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -1045,9 +1045,7 @@ void cm_rtpbcast_destroy_session(janus_plugin_session *handle, int *error) {
 	/* If session is watching something, remove it from listeners */
 	/* TODO: abstract "attach to source" and "remove from source" with a special func
 	 * also see below at cm_rtpbcast_stop_udp_relays() for example */
-
 	janus_mutex_lock(&session->mutex);
-
 	if(session->source) {
 		janus_mutex_lock(&session->source->mutex);
 		session->source->listeners = g_list_remove_all(session->source->listeners, session);
@@ -1060,9 +1058,7 @@ void cm_rtpbcast_destroy_session(janus_plugin_session *handle, int *error) {
 	if(session->mps)
 		g_list_foreach(session->mps, cm_rtpbcast_mountpoint_destroy, NULL);
 	session->mps = NULL;
-
 	janus_mutex_unlock(&session->mutex);
-
 	janus_mutex_lock(&sessions_mutex);
 	if(!session->destroyed) {
 		session->destroyed = janus_get_monotonic_time();

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -1045,6 +1045,9 @@ void cm_rtpbcast_destroy_session(janus_plugin_session *handle, int *error) {
 	/* If session is watching something, remove it from listeners */
 	/* TODO: abstract "attach to source" and "remove from source" with a special func
 	 * also see below at cm_rtpbcast_stop_udp_relays() for example */
+
+	janus_mutex_lock(&session->mutex);
+
 	if(session->source) {
 		janus_mutex_lock(&session->source->mutex);
 		session->source->listeners = g_list_remove_all(session->source->listeners, session);
@@ -1057,6 +1060,8 @@ void cm_rtpbcast_destroy_session(janus_plugin_session *handle, int *error) {
 	if(session->mps)
 		g_list_foreach(session->mps, cm_rtpbcast_mountpoint_destroy, NULL);
 	session->mps = NULL;
+
+	janus_mutex_unlock(&session->mutex);
 
 	janus_mutex_lock(&sessions_mutex);
 	if(!session->destroyed) {
@@ -2713,6 +2718,11 @@ static void cm_rtpbcast_relay_rtp_packet(gpointer data, gpointer user_data) {
 	packet->data->timestamp = htonl(session->context.last_ts[j]);
 	packet->data->seq_number = htons(session->context.last_seq[j]);
 
+	int i=0;
+	for(i=0;i<100000000; i++) {
+		if(session->source) {}
+	}
+
 	if (session->source) {
 		if(gateway != NULL) {
 			gateway->relay_rtp(session->handle, packet->is_video, (char *)packet->data, packet->length);
@@ -3365,39 +3375,49 @@ void cm_rtpbcast_unschedule_switch(cm_rtpbcast_session *sessid) {
 static void cm_rtpbcast_execute_switching(gpointer data, gpointer user_data) {
 	cm_rtpbcast_session *sessid = (cm_rtpbcast_session *)data;
 	cm_rtpbcast_rtp_source *source = (cm_rtpbcast_rtp_source *)user_data;
-	cm_rtpbcast_rtp_source *oldsrc = sessid->source;
+
+	if(sessid == NULL)
+		return;
 
 	janus_mutex_lock(&sessid->mutex);
+	cm_rtpbcast_rtp_source *oldsrc = sessid->source;
 
+	if(oldsrc == NULL) {
+		janus_mutex_unlock(&sessid->mutex);
+		return;
+	}
+
+	janus_mutex_lock(&oldsrc->mutex);
 	/* If somehow the sources are the same, prevent a deadlock */
-	if (source != oldsrc)
-		janus_mutex_lock(&oldsrc->mutex);
+	if (source != oldsrc) {
+		/* Remove from old source and attach to new source */
+		oldsrc->listeners = g_list_remove_all(oldsrc->listeners, sessid);
+		source->listeners = g_list_prepend(source->listeners, sessid);
 
-	/* Remove from old source and attach to new source */
-	oldsrc->listeners = g_list_remove_all(oldsrc->listeners, sessid);
-	source->listeners = g_list_prepend(source->listeners, sessid);
-	sessid->source = source;
-	JANUS_LOG(LOG_VERB, "Session 0x%x switched to source 0x%x\n", GPOINTER_TO_UINT(sessid), GPOINTER_TO_UINT(source));
+		int i=0;
+		for(i=0;i<100000000; i++) {
+			sessid->source = source;
+		}
 
-	if (source != oldsrc)
-		janus_mutex_unlock(&oldsrc->mutex);
+		JANUS_LOG(LOG_VERB, "Session 0x%x switched to source 0x%x\n", GPOINTER_TO_UINT(sessid), GPOINTER_TO_UINT(source));
 
+		json_t *event = json_object();
+		json_object_set_new(event, "streaming", json_string("event"));
+
+		json_t *result = json_object();
+		json_object_set_new(result, "event", json_string("changed"));
+
+		json_t *streams = cm_rtpbcast_sources_to_json(source->mp->sources, sessid);
+		json_object_set_new(result, "streams", streams);
+
+		json_object_set_new(event, "result", result);
+		char *event_text = json_dumps(event, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
+		json_decref(event);
+
+		gateway->push_event(sessid->handle, &cm_rtpbcast_plugin, NULL, event_text, NULL, NULL);
+	}
+	janus_mutex_unlock(&oldsrc->mutex);
 	janus_mutex_unlock(&sessid->mutex);
-
-	json_t *event = json_object();
-	json_object_set_new(event, "streaming", json_string("event"));
-	json_t *result = json_object();
-
-	json_object_set_new(result, "event", json_string("changed"));
-
-	json_t *streams = cm_rtpbcast_sources_to_json(source->mp->sources, sessid);
-	json_object_set_new(result, "streams", streams);
-
-	json_object_set_new(event, "result", result);
-	char *event_text = json_dumps(event, JSON_INDENT(3) | JSON_PRESERVE_ORDER);
-	json_decref(event);
-
-	gateway->push_event(sessid->handle, &cm_rtpbcast_plugin, NULL, event_text, NULL, NULL);
 }
 
 void cm_rtpbcast_process_switchers(cm_rtpbcast_rtp_source *src) {


### PR DESCRIPTION
Core dump:
```
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `/usr/bin/janus -o -C /opt/janus-cluster/janus/etc/janus/janus.cfg -L /opt/janus'.
Program terminated with signal 11, Segmentation fault.
#0  0x00000000004351fc in janus_plugin_relay_rtp ()
(gdb) where
#0  0x00000000004351fc in janus_plugin_relay_rtp ()
#1  0x00007fd1696b9d51 in ?? () from /opt/janus-cluster/janus/usr/lib/janus/plugins.enabled/libjanus_rtpbroadcast.so
#2  0x00007fd16fec266d in g_list_foreach () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#3  0x00007fd1696b9329 in ?? () from /opt/janus-cluster/janus/usr/lib/janus/plugins.enabled/libjanus_rtpbroadcast.so
#4  0x00007fd16fee7f45 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#5  0x00007fd16ebabb50 in start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
#6  0x00007fd16e8f5fbd in clone () from /lib/x86_64-linux-gnu/libc.so.6
#7  0x0000000000000000 in ?? ()
```
Syslog:
```
2016-09-02T14:56:00.216325+00:00 janus2 kernel: [11598360.562881] PyaQzKBuensNUDh[6873] general protection ip:4351fc sp:7fd1537fcfc0 error:0 in janus[400000+81000]
```

https://cargomedia.loggly.com/search#terms=tag%3Asyslog%20segfault