### PR TITLE
Make multi-thread safe for sessions, mp and sources - take 2

### DIFF
--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -1056,6 +1056,7 @@ void cm_rtpbcast_destroy_session(janus_plugin_session *handle, int *error) {
 		return;
 	}
 	janus_mutex_lock(&session->mutex);
+	session->stopping = TRUE;
 	JANUS_LOG(LOG_VERB, "Removing CM RTP Broadcast session...\n");
 	/* If session is watching something, remove it from listeners */
 	/* TODO: abstract "attach to source" and "remove from source" with a special func
@@ -2722,7 +2723,7 @@ static void cm_rtpbcast_relay_rtp_packet(gpointer data, gpointer user_data) {
 		//~ JANUS_LOG(LOG_ERR, "Invalid session handle...\n");
 		return;
 	}
-	if(!session->started || session->paused) {
+	if(!session->started || session->stopping || session->paused) {
 		janus_mutex_unlock(&session->mutex);
 		//~ JANUS_LOG(LOG_ERR, "Streaming not started yet for this session...\n");
 		return;

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -2729,7 +2729,7 @@ static void cm_rtpbcast_relay_rtp_packet(gpointer data, gpointer user_data) {
 	}
 	if(session->destroyed) {
 		janus_mutex_unlock(&session->mutex);
-		//~ JANUS_LOG(LOG_ERR, "Streaming not started, session destoryed...\n");
+		//~ JANUS_LOG(LOG_ERR, "Streaming finished, session destroyed...\n");
 		return;
 	}
 

--- a/libjanus_rtpbroadcast.c
+++ b/libjanus_rtpbroadcast.c
@@ -1046,7 +1046,7 @@ void cm_rtpbcast_destroy_session(janus_plugin_session *handle, int *error) {
 	if(!handle)
 		return;
 
-	if(handle->plugin_handle)
+	if(!handle->plugin_handle)
 		return;
 
 	cm_rtpbcast_session *session = (cm_rtpbcast_session *)handle->plugin_handle;


### PR DESCRIPTION
Version [0.0.24](https://github.com/cargomedia/janus-gateway-rtpbroadcast/releases/tag/v0.0.24) crashes with
```
Core was generated by `/usr/bin/janus -o -C /opt/janus-cluster/janus/etc/janus/janus.cfg -L /opt/janus'.
Program terminated with signal 11, Segmentation fault.
#0  0x00007f81c7aab1b6 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
(gdb) where
#0  0x00007f81c7aab1b6 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#1  0x00007f81c7aab419 in g_mutex_lock () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#2  0x00007f81c7a4628a in g_async_queue_push () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#3  0x00007f81c1263383 in ?? () from /opt/janus-cluster/janus/usr/lib/janus/plugins.enabled/libjanus_rtpbroadcast.so
#4  0x00007f81c7a6c66d in g_list_foreach () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#5  0x00007f81c12627f8 in ?? () from /opt/janus-cluster/janus/usr/lib/janus/plugins.enabled/libjanus_rtpbroadcast.so
#6  0x00007f81c7a91f45 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#7  0x00007f81c6755b50 in start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
#8  0x00007f81c649ffbd in clone () from /lib/x86_64-linux-gnu/libc.so.6
#9  0x0000000000000000 in ?? ()
```

The error happens between following operations triggered by `g_list_foreach`:
 - cm_rtpbcast_notify_supers -> cm_rtpbcast_notify_session
 - cm_rtpbcast_process_switchers -> cm_rtpbcast_execute_switching
 - cm_rtpbcast_destroy_session -> cm_rtpbcast_mountpoint_destroy
 - cm_rtpbcast_relay_thread -> cm_rtpbcast_relay_rtp_packet